### PR TITLE
[Result] Support Non-Default Namespace for Model Type Export

### DIFF
--- a/app-modules/post/resources/js/types/model.ts
+++ b/app-modules/post/resources/js/types/model.ts
@@ -1,0 +1,22 @@
+export type Comment = {
+    id: string;
+    post_id: string;
+    user_id: number;
+    content?: string;
+    status: string;
+    created_at?: string;
+    updated_at?: string;
+    post?: Post;
+};
+export type Post = {
+    id: string;
+    title: string;
+    content?: string;
+    tags?: any[];
+    metadata?: Record<string, any>;
+    status: string;
+    user_id: number;
+    created_at?: string;
+    updated_at?: string;
+    comments?: Comment[];
+};


### PR DESCRIPTION
PR for showing output diff result for the following PR

- https://github.com/7nohe/laravel-typegen/pull/29

Command used for executing laravel-typegen is

```bash
sail pnpm typegen
```

https://github.com/NaoyaMiyagawa/laravel-typegen-sample/blob/d7ab9e43a1c3e349425471b6928617d115e3e242/package.json#L4-L10